### PR TITLE
Added Specialities (Professional) as entity and script for testing schema

### DIFF
--- a/unicorn-api/app/models/connection_token.rb
+++ b/unicorn-api/app/models/connection_token.rb
@@ -1,3 +1,3 @@
 class ConnectionToken < ApplicationRecord
-  belongs_to :medical_centers
+  belongs_to :medical_centers, optional: true
 end

--- a/unicorn-api/app/models/consult.rb
+++ b/unicorn-api/app/models/consult.rb
@@ -1,5 +1,5 @@
 class Consult < ApplicationRecord
   has_many :movements
-  belongs_to :patients
-  belongs_to :professionals
+  belongs_to :patients, optional: true
+  belongs_to :professionals, optional: true
 end

--- a/unicorn-api/app/models/document.rb
+++ b/unicorn-api/app/models/document.rb
@@ -1,3 +1,3 @@
 class Document < ApplicationRecord
-  belongs_to :movements
+  belongs_to :movements, optional: true
 end

--- a/unicorn-api/app/models/measurement.rb
+++ b/unicorn-api/app/models/measurement.rb
@@ -1,3 +1,3 @@
 class Measurement < ApplicationRecord
-  belongs_to :metrics
+  belongs_to :metrics, optional: true
 end

--- a/unicorn-api/app/models/movement.rb
+++ b/unicorn-api/app/models/movement.rb
@@ -1,6 +1,6 @@
 class Movement < ApplicationRecord
-  belongs_to :consults
+  belongs_to :consults, optional: true
   has_many :documents
   has_many :movement_details
-  belongs_to :movement_type
+  belongs_to :movement_type, optional: true
 end

--- a/unicorn-api/app/models/movement_detail.rb
+++ b/unicorn-api/app/models/movement_detail.rb
@@ -1,3 +1,3 @@
 class MovementDetail < ApplicationRecord
-  belongs_to :movements
+  belongs_to :movements, optional: true
 end

--- a/unicorn-api/app/models/permission.rb
+++ b/unicorn-api/app/models/permission.rb
@@ -1,5 +1,5 @@
 class Permission < ApplicationRecord
   has_and_belongs_to_many :accesses
-  belongs_to :patients
-  belongs_to :professionals
+  belongs_to :patients, optional: true
+  belongs_to :professionals, optional: true
 end

--- a/unicorn-api/app/models/professional.rb
+++ b/unicorn-api/app/models/professional.rb
@@ -2,4 +2,5 @@ class Professional < ApplicationRecord
   has_many :consults
   has_and_belongs_to_many :medical_centers
   has_many :permissions
+  belongs_to :specialities, optional: true
 end

--- a/unicorn-api/app/models/speciality.rb
+++ b/unicorn-api/app/models/speciality.rb
@@ -1,0 +1,3 @@
+class Speciality < ApplicationRecord
+  has_many :professionals
+end

--- a/unicorn-api/db/migrate/20171008192849_create_professionals.rb
+++ b/unicorn-api/db/migrate/20171008192849_create_professionals.rb
@@ -9,7 +9,7 @@ class CreateProfessionals < ActiveRecord::Migration[5.1]
       t.string :job_title, null: false
       t.date :grant_date, null: false
       t.string :granting_entity, null: false
-      t.string :speciality, null: false
+      t.references :speciality
       t.string :registration_number, null: false
       t.date :registration_date, null: false
       t.boolean :freelance, default: false

--- a/unicorn-api/db/migrate/20171010235512_create_specialities.rb
+++ b/unicorn-api/db/migrate/20171010235512_create_specialities.rb
@@ -1,0 +1,9 @@
+class CreateSpecialities < ActiveRecord::Migration[5.1]
+  def change
+    create_table :specialities do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :specialities, :name, unique: true
+  end
+end

--- a/unicorn-api/db/schema.rb
+++ b/unicorn-api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171009150336) do
+ActiveRecord::Schema.define(version: 20171010235512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 20171009150336) do
     t.string "job_title", null: false
     t.date "grant_date", null: false
     t.string "granting_entity", null: false
-    t.string "speciality", null: false
+    t.bigint "speciality_id"
     t.string "registration_number", null: false
     t.date "registration_date", null: false
     t.boolean "freelance", default: false
@@ -150,6 +150,14 @@ ActiveRecord::Schema.define(version: 20171009150336) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["rut"], name: "index_professionals_on_rut", unique: true
+    t.index ["speciality_id"], name: "index_professionals_on_speciality_id"
+  end
+
+  create_table "specialities", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_specialities_on_name", unique: true
   end
 
 end

--- a/unicorn-api/test/fixtures/specialities.yml
+++ b/unicorn-api/test/fixtures/specialities.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/unicorn-api/test/models/speciality_test.rb
+++ b/unicorn-api/test/models/speciality_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SpecialityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Cambios
Ahora las especialidades de los profesionales están en una entidad a parte, para que sean únicas y se puedan asociar luego a los profesionales.

## ¿Cómo probar?
- Crear base de datos y schema con `rake db:create`, `rake db:migrate`
- Ingresar a la consola de Rails con `rails c`
- Correr script con `load test/test_schema.rb`
- Realizar pruebas con los modelos como las siguientes:

Retorna todos los profesionales:
> Professional.all

Retorna los centros médicos en que trabaja el profesional 1:
> Professional.find(1).medical_centers

Retorna los profesionales del centro médico 1:
> MedicalCenter.find(1).professionals